### PR TITLE
Delete the instruction to make C2A directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 ## C2A Integration
 
 - Make `FlightSW` directory at same directory with `S2E-AOBC`
-- Make `C2A` directory in `FlightSW` and clone a [C2A-AOBC](https://github.com/ut-issl/c2a-aobc) repository
+- Clone a [C2A-AOBC](https://github.com/ut-issl/c2a-aobc) repository into `FlightSW`
 - Edit `S2E-AOBC/CMakeLists.txt` as follows
   - `set(USE_C2A OFF)` -> `set(USE_C2A ON)`
 - Build `S2E-AOBC`


### PR DESCRIPTION
## 概要
READMEの修正

## Issue
- #19 

## 詳細
FlightSW下にC2A directoryを作成するという指示を削除し，FlightSW直下にFSWを置くように記述した

## 検証結果
test へのリンクや，検証結果へのリンク

## 影響範囲
XX系の動作がガラッと変わる，とか．

## 補足
何かあれば

## 注意
- 関連する Projects が存在する場合，それの紐付けを行うこと
- Assignees を設定すること
- 可能ならば Reviewers を設定すること
- 可能ならば `priority` ラベルを付けること
