### PR TITLE
Fix sensor ID for MPU gyro

### DIFF
--- a/data/initialize_files/components/MPU9250.ini
+++ b/data/initialize_files/components/MPU9250.ini
@@ -1,4 +1,4 @@
-[GYRO_SENSOR_1]
+[GYRO_SENSOR_2]
 prescaler = 1
 
 // Quaternion from body frame to component frame
@@ -8,7 +8,7 @@ quaternion_b2c(1) = 0.0
 quaternion_b2c(2) =-0.70710678118
 quaternion_b2c(3) = 0.0
 
-[SENSOR_BASE_GYRO_SENSOR_1]
+[SENSOR_BASE_GYRO_SENSOR_2]
 // Scale Factor Matrix (3×3)
 // (0) = (0,0), (1) = (0,1), (2) = (0,2), 
 scale_factor_c(0) = 1.0


### PR DESCRIPTION
## 概要
センサーID設定の修正

## Issue
NA

## 詳細
s2e-coreアップデート対応時にセンサーID設定が間違っていたので修正した。

## 検証結果
手元で確認した

## 影響範囲
MPUジャイロ模擬が正しく動かない

## 補足
NA

## 注意
NA