### PR TITLE
Fix typo of area settings in satellite_structure.ini

### DIFF
--- a/data/initialize_files/satellite_structure.ini
+++ b/data/initialize_files/satellite_structure.ini
@@ -34,8 +34,8 @@ area_2_m2 = 0.035 //PY
 area_3_m2 = 0.035 //MY
 area_4_m2 = 0.02 //PZ
 area_5_m2 = 0.02 //MZ
-area_5_m2 = 0.25 //PZ SAP front
-area_5_m2 = 0.25 //PZ SAP back
+area_6_m2 = 0.25 //PZ SAP front
+area_7_m2 = 0.25 //PZ SAP back
 
 // Position vector of each surface geometric center @ body frame [m]
 position_0_b_m(0) = 0.05   //PX body


### PR DESCRIPTION
## 概要
SSIA

## Issue
- resolve #32 

## 詳細
Areas of `surface_6` and `surface_7` are not set correctly, which was fixed. 

## 検証結果
### Before fix

Areas are set as zero.

![image](https://github.com/ut-issl/s2e-aobc/assets/93800108/ea2cebe5-6f56-43f8-a9ef-ed7a08e9155d)

### After fix

Areas are set correctly.

![image (1)](https://github.com/ut-issl/s2e-aobc/assets/93800108/c2256171-f062-4be7-b0cd-63e289e9426d)


## 影響範囲
Small

## 補足
何かあれば

## 注意
- 関連する Projects が存在する場合，それの紐付けを行うこと
- Assignees を設定すること
- 可能ならば Reviewers を設定すること
- 可能ならば `priority` ラベルを付けること
