### PR TITLE
ユーザーが外部磁気センサ I2Cアドレスを変更できるよう修正

### DIFF
--- a/data/initialize_files/components/rm3100_external.ini
+++ b/data/initialize_files/components/rm3100_external.ini
@@ -45,6 +45,9 @@ normal_random_standard_deviation_c_nT(2) = 15.0
 range_to_constant_nT = 1.0e6  // smaller than Range_to_zero
 range_to_zero_nT = 1.5e6
 
+[I2C_PORT_2]
+i2c_address = 0x23
+
 [POWER_PORT]
 minimum_voltage_V = 3.3 // V
 assumed_power_consumption_W = 0.03 //W

--- a/example/data/initialize_files/components/rm3100_external.ini
+++ b/example/data/initialize_files/components/rm3100_external.ini
@@ -45,6 +45,9 @@ normal_random_standard_deviation_c_nT(2) = 15.0
 range_to_constant_nT = 1.0e6  // smaller than Range_to_zero
 range_to_zero_nT = 1.5e6
 
+[I2C_PORT_2]
+i2c_address = 0x23
+
 [POWER_PORT]
 minimum_voltage_V = 3.3 // V
 assumed_power_consumption_W = 0.03 //W

--- a/src/simulation/spacecraft/aocs_module_components.cpp
+++ b/src/simulation/spacecraft/aocs_module_components.cpp
@@ -75,9 +75,11 @@ AocsModuleComponents::AocsModuleComponents(const Dynamics *dynamics, Structure *
                             0, rm3100_aobc_hils_port_id, 0x20, aobc_, hils_port_manager_);
   const std::string rm3100_ext_ini_path = iniAccess.ReadString("COMPONENTS_FILE", "magsensor_h_ext_file");
   const unsigned int rm3100_ext_hils_port_id = iniAccess.ReadInt("COM_PORT", "rm3100_ext_hils_port_id");
+  IniAccess rm3100_ext_ini_access = IniAccess(rm3100_ext_ini_path);
+  const uint8_t rm3100_ext_i2c_address = (uint8_t)rm3100_ext_ini_access.ReadInt("I2C_PORT_2", "i2c_address");
   rm3100_ext_ = new RM3100(Magnetometer(InitMagnetometer(clock_generator, power_controller_->GetPowerPort((int)PowerPortIdx::RM), 2,
                                                         rm3100_ext_ini_path, compo_step_sec, &local_environment_->GetGeomagneticField())),
-                           0, rm3100_ext_hils_port_id, 0x23, aobc_, hils_port_manager_);
+                           0, rm3100_ext_hils_port_id, rm3100_ext_i2c_address, aobc_, hils_port_manager_);
 
   const std::string nanoSSOC_D60_ini_path = iniAccess.ReadString("COMPONENTS_FILE", "ss_file");
   const unsigned int nanoSSOC_D60_pz_hils_port_id = iniAccess.ReadInt("COM_PORT", "nanoSSOC_D60_pz_hils_port_id");

--- a/src/simulation/spacecraft/aocs_module_components.cpp
+++ b/src/simulation/spacecraft/aocs_module_components.cpp
@@ -65,20 +65,20 @@ AocsModuleComponents::AocsModuleComponents(const Dynamics *dynamics, Structure *
   const std::string mpu9250_mag_ini_path = iniAccess.ReadString("COMPONENTS_FILE", "magsensor_l_file");
   const unsigned int mpu9250_mag_hils_port_id = iniAccess.ReadInt("COM_PORT", "mpu9250_mag_hils_port_id");
   mpu9250_mag_ = new MPU9250_MAG(InitMagnetometer(clock_generator, power_controller_->GetPowerPort((int)PowerPortIdx::MPU), 2, mpu9250_mag_ini_path,
-                                                 compo_step_sec, &(local_environment_->GetGeomagneticField())),
+                                                  compo_step_sec, &(local_environment_->GetGeomagneticField())),
                                  0, mpu9250_mag_hils_port_id, 0x0c, aobc_, hils_port_manager_, mpu9250_gyro_->GetIsMagOn());
 
   const std::string rm3100_aobc_ini_path = iniAccess.ReadString("COMPONENTS_FILE", "magsensor_h_aobc_file");
   const unsigned int rm3100_aobc_hils_port_id = iniAccess.ReadInt("COM_PORT", "rm3100_aobc_hils_port_id");
   rm3100_aobc_ = new RM3100(Magnetometer(InitMagnetometer(clock_generator, power_controller_->GetPowerPort((int)PowerPortIdx::RM), 1,
-                                                         rm3100_aobc_ini_path, compo_step_sec, &local_environment_->GetGeomagneticField())),
+                                                          rm3100_aobc_ini_path, compo_step_sec, &local_environment_->GetGeomagneticField())),
                             0, rm3100_aobc_hils_port_id, 0x20, aobc_, hils_port_manager_);
   const std::string rm3100_ext_ini_path = iniAccess.ReadString("COMPONENTS_FILE", "magsensor_h_ext_file");
   const unsigned int rm3100_ext_hils_port_id = iniAccess.ReadInt("COM_PORT", "rm3100_ext_hils_port_id");
   IniAccess rm3100_ext_ini_access = IniAccess(rm3100_ext_ini_path);
   const uint8_t rm3100_ext_i2c_address = (uint8_t)rm3100_ext_ini_access.ReadInt("I2C_PORT_2", "i2c_address");
   rm3100_ext_ = new RM3100(Magnetometer(InitMagnetometer(clock_generator, power_controller_->GetPowerPort((int)PowerPortIdx::RM), 2,
-                                                        rm3100_ext_ini_path, compo_step_sec, &local_environment_->GetGeomagneticField())),
+                                                         rm3100_ext_ini_path, compo_step_sec, &local_environment_->GetGeomagneticField())),
                            0, rm3100_ext_hils_port_id, rm3100_ext_i2c_address, aobc_, hils_port_manager_);
 
   const std::string nanoSSOC_D60_ini_path = iniAccess.ReadString("COMPONENTS_FILE", "ss_file");


### PR DESCRIPTION
## Issue
#11 

## 詳細
iniファイル内で外部磁気センサI2Cアドレスを設定できるように修正した。

## 検証結果
I2Cアドレスが正しく設定されることを確認した。

<img width="1611" alt="image" src="https://github.com/ut-issl/s2e-aobc/assets/19573779/db500838-f8c1-4989-bcb8-8d6547f3b2f3">

## 補足
NA
