### PR TITLE
Update c2a-aobc version in CI to v7.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
       - 'src/**'
 
 env:
-  C2A_AOBC_VERSION: v6.1.4
+  C2A_AOBC_VERSION: v7.0.0
 
 jobs:
   build_s2e_win:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_policy(SET CMP0048 NEW)
 project(S2E_AOBC
   LANGUAGES CXX
   DESCRIPTION "S2E_AOBC"
-  VERSION 4.0.0
+  VERSION 4.0.1
   )
 
 cmake_minimum_required(VERSION 3.13)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@
 
 - Make the `FlightSW` directory at the same directory with `s2e-aobc`
 - Clone the [C2A-AOBC](https://github.com/ut-issl/c2a-aobc) repository into `FlightSW`
-  - Current support version: [v7.0.0](https://github.com/ut-issl/c2a-aobc/release/tag/v7.0.0)
+  - Current support version: [v7.0.0](https://github.com/ut-issl/c2a-aobc/releases/tag/v7.0.0)
 - Directory Construction
   ```
   - s2e-aobc


### PR DESCRIPTION
## Issue
NA

## 詳細
CIの中でビルド対象とするC2A-AOBC v7.0.0に更新する。  
ついでにREADMEのC2A-CORE v7.0.0へのリンクミスがあったので修正した。

## 検証結果
CIを確認する

## 補足
NA

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
