### PR TITLE
Remove warnings in Windows Visual Studio build

### DIFF
--- a/src/component/aocs/oem7600.cpp
+++ b/src/component/aocs/oem7600.cpp
@@ -380,8 +380,8 @@ std::string Oem7600::GenerateTelemetryHeaderBinary(const std::string telemetry_n
   }
 
   // week(uint16), msec(uint32)
-  tlm[tlm_parse_pointer++] = (unsigned char)(((unsigned short)(gps_time_week_) & 0x00ff));
-  tlm[tlm_parse_pointer++] = (unsigned char)(((unsigned short)(gps_time_week_) & 0xff00) >> 8);
+  tlm[tlm_parse_pointer++] = (unsigned char)(((unsigned short)(gps_time_week_)&0x00ff));
+  tlm[tlm_parse_pointer++] = (unsigned char)(((unsigned short)(gps_time_week_)&0xff00) >> 8);
 
   unsigned int gps_time_msec = (unsigned int)(gps_time_s_ * 1000.0);
   tlm[tlm_parse_pointer++] = (unsigned char)((gps_time_msec & 0x000000ff));

--- a/src/component/aocs/oem7600.cpp
+++ b/src/component/aocs/oem7600.cpp
@@ -143,7 +143,7 @@ Oem7600Command Oem7600::DecodeCommand() {
   // find empty space character(separator)
   for (size_t i = 0; i < rx_buffer_.size(); i++) {
     if (rx_buffer_[i] == ' ') {
-      space_pos[space_pos_count] = i;
+      space_pos[space_pos_count] = (uint8_t)i;
       space_pos_count++;
 
       if (space_pos_count > OEM7600_MAX_CMD_ARG) {

--- a/src/component/aocs/oem7600.cpp
+++ b/src/component/aocs/oem7600.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>  // toupper
 #include <library/utilities/macros.hpp>
+#include <locale>
 
 #define MAX_CMD_LEN 1024                        // TBD
 #define MAX_TLM_LEN 1024                        // TBD
@@ -307,7 +308,8 @@ std::string Oem7600::GenerateTelemetryHeaderAscii(const std::string telemetry_na
 
   // Sync + Message
   std::string str_tmp = "#" + telemetry_name;
-  std::transform(telemetry_name.begin(), telemetry_name.end(), (str_tmp.begin() + 1), ::toupper);
+  std::locale loc = std::locale::classic();
+  std::transform(telemetry_name.begin(), telemetry_name.end(), (str_tmp.begin() + 1), [loc](char c) { return std::toupper(c, loc); });
 
   std::string port = "COM" + WriteScalar((int)(telemetry_channel_), 1);  // Port
   str_tmp += "," + port;                                                 // after port, "," is already added (WriteScalar did it)
@@ -378,8 +380,8 @@ std::string Oem7600::GenerateTelemetryHeaderBinary(const std::string telemetry_n
   }
 
   // week(uint16), msec(uint32)
-  tlm[tlm_parse_pointer++] = (unsigned char)(((unsigned short)(gps_time_week_)&0x00ff));
-  tlm[tlm_parse_pointer++] = (unsigned char)(((unsigned short)(gps_time_week_)&0xff00) >> 8);
+  tlm[tlm_parse_pointer++] = (unsigned char)(((unsigned short)(gps_time_week_) & 0x00ff));
+  tlm[tlm_parse_pointer++] = (unsigned char)(((unsigned short)(gps_time_week_) & 0xff00) >> 8);
 
   unsigned int gps_time_msec = (unsigned int)(gps_time_s_ * 1000.0);
   tlm[tlm_parse_pointer++] = (unsigned char)((gps_time_msec & 0x000000ff));

--- a/src/component/aocs/oem7600.hpp
+++ b/src/component/aocs/oem7600.hpp
@@ -33,7 +33,7 @@ typedef enum { OEM7600_TLM_ID_BEST_XYZ = 0x00F1, OEM7600_TLM_ID_HARDWARE_MONITOR
  * @struct Oem7600Telemetry
  * @brief OEM7600 telemetry structure
  */
-typedef struct {
+struct Oem7600Telemetry {
   std::string telemetry_name = "";    //!< Telemetry name
   std::string out_type = "once";      //!< Output type
   unsigned int output_frequency = 0;  //!< Output frequency
@@ -49,7 +49,7 @@ typedef struct {
       count_to_out = 0;
     }
   }
-} Oem7600Telemetry;
+};
 
 /**
  * @class OEM7600

--- a/src/component/aocs/rw0003.cpp
+++ b/src/component/aocs/rw0003.cpp
@@ -30,7 +30,7 @@ void Rw0003::MainRoutine(const int time_count) {
   // Generate TLM
   if (is_rw_initialized_ == true) {
     CalcTorque();
-    WriteFloatTlm(kReadAddressTemperature_, temperature_degC_);
+    WriteFloatTlm(kReadAddressTemperature_, (float)temperature_degC_);
     WriteFloatTlm(kReadAddressSpeed_, (float)angular_velocity_rad_s_);
   }
 
@@ -191,7 +191,7 @@ void Rw0003::WriteFloatTlm(uint8_t address, float value) {
   tlm_slip = encode_slip(tlm);
 
   // Write Tlm
-  WriteRegister(address, &tlm_slip[0], tlm_slip.size());
+  WriteRegister(address, &tlm_slip[0], (uint8_t)tlm_slip.size());
 }
 
 void Rw0003::Initialize() {

--- a/src/component/aocs/stim210.cpp
+++ b/src/component/aocs/stim210.cpp
@@ -75,7 +75,7 @@ int Stim210::ParseCommand(const int command_size) {
           if (operation_mode_ == OPERATION_SERVICE_MODE) ret = AnalyzeCmdSetLPFFrequency(cmd);
           break;
         default:
-          ret = -1;
+          return = -1;
       }
     }
   }

--- a/src/component/aocs/stim210.cpp
+++ b/src/component/aocs/stim210.cpp
@@ -45,7 +45,7 @@ std::string Stim210::GetLogHeader() const {
 int Stim210::ParseCommand(const int command_size) {
   std::vector<unsigned char> cmd = rx_buffer_;
   int idx = 0;
-  int ret;
+  int ret = -1;
   for (int i = 0; i < command_size; i++) {
     cmd[idx] = rx_buffer_[i];
     idx++;
@@ -75,7 +75,7 @@ int Stim210::ParseCommand(const int command_size) {
           if (operation_mode_ == OPERATION_SERVICE_MODE) ret = AnalyzeCmdSetLPFFrequency(cmd);
           break;
         default:
-          return -1;
+          ret = -1;
       }
     }
   }

--- a/src/component/aocs/stim210.cpp
+++ b/src/component/aocs/stim210.cpp
@@ -75,7 +75,7 @@ int Stim210::ParseCommand(const int command_size) {
           if (operation_mode_ == OPERATION_SERVICE_MODE) ret = AnalyzeCmdSetLPFFrequency(cmd);
           break;
         default:
-          return = -1;
+          return -1;
       }
     }
   }

--- a/src/component/aocs/stim210.cpp
+++ b/src/component/aocs/stim210.cpp
@@ -28,7 +28,7 @@ void Stim210::MainRoutine(const int time_count) {
   for (size_t i = 0; i < kGyroDimension; i++) {
     temperature_c_degC_[i] = 30.0 + ((double)i) * 0.1;  // TODO: 温度の反映
   }
-  // Send Tlmetry
+  // Send Telemetry
   SendTelemetry(0);
 
   return;

--- a/src/simulation/spacecraft/aocs_module_components.cpp
+++ b/src/simulation/spacecraft/aocs_module_components.cpp
@@ -103,7 +103,7 @@ AocsModuleComponents::AocsModuleComponents(const Dynamics *dynamics, Structure *
     const unsigned int nanoSSOC_D60_hils_port_id = ini_access.ReadInt("COM_PORT", hils_port.c_str());
 
     const std::string ss_section_name = "I2C_PORT_" + std::to_string(static_cast<long long>(ss_idx));
-    const uint8_t i2c_address = ss_ini_file.ReadInt(ss_section_name.c_str(), "i2c_address");
+    const uint8_t i2c_address = (uint8_t)ss_ini_file.ReadInt(ss_section_name.c_str(), "i2c_address");
     NanoSsocD60 *ss =
         new NanoSsocD60(InitSunSensor(clock_generator, power_controller_->GetPowerPort((int)PowerPortIdx::SS), ss_idx, nanoSSOC_D60_ini_path,
                                       &(local_environment_->GetSolarRadiationPressure()), &(local_environment_->GetCelestialInformation())),


### PR DESCRIPTION
## Issue
NA

## 詳細
CIのWindows Visual Studio buildで出ていたwarningsを消去するための修正。

## 検証結果
CI結果を見てください。

## 補足
NA

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
