### PR TITLE
SagittaのUnixTime変更コマンドに対応

### DIFF
--- a/src/component/aocs/sagitta.cpp
+++ b/src/component/aocs/sagitta.cpp
@@ -131,7 +131,7 @@ int Sagitta::AnalyzeCmd(std::vector<uint8_t> decoded_rx) {
 int Sagitta::AnalyzeCmdSetTime(std::vector<uint8_t> decoded_rx) {
   if (decoded_rx[2] != kActionIdSetTime_) return -1;
 
-  memcpy(&unix_time_us_, &decoded_rx[3], sizeof(unix_time_us_)); 
+  memcpy(&unix_time_us_, &decoded_rx[3], sizeof(unix_time_us_));
 
   return 1;
 }

--- a/src/component/aocs/sagitta.cpp
+++ b/src/component/aocs/sagitta.cpp
@@ -113,7 +113,7 @@ int Sagitta::AnalyzeCmdBoot(std::vector<uint8_t> decoded_rx) {
 int Sagitta::AnalyzeCmd(std::vector<uint8_t> decoded_rx) {
   if (decoded_rx[0] != kAddress_) return -1;
   const int cmd_id = decoded_rx[1];
-  
+
   switch (cmd_id) {
     case kCmdSetParam_:
       AnalyzeCmdRequestTlm(decoded_rx);
@@ -130,7 +130,7 @@ int Sagitta::AnalyzeCmd(std::vector<uint8_t> decoded_rx) {
 
 int Sagitta::AnalyzeCmdSetTime(std::vector<uint8_t> decoded_rx) {
   if (decoded_rx[2] != kActionIdSetTime_) return -1;
-  
+
   memcpy(&unix_time_us_, &decoded_rx[3], sizeof(unix_time_us_)); 
 
   return 1;

--- a/src/component/aocs/sagitta.hpp
+++ b/src/component/aocs/sagitta.hpp
@@ -134,15 +134,31 @@ class Sagitta : public StarSensor, public UartCommunicationWithObc {
    * @return 1: Success, -1: Error
    */
   int AnalyzeCmdBoot(std::vector<uint8_t> decoded_rx);
+
+  /**
+   * @fn AnalyzeCmd
+   * @brief Analyze command
+   * @param [in] decoded_rx: Decoded command data
+   * @return 1: Success, -1: Error
+   */
+  int AnalyzeCmd(std::vector<uint8_t> decoded_rx);
+
+  /**
+   * @fn AnalyzeCmdSetTime
+   * @brief Analyze Set Time command
+   * @param [in] decoded_rx: Decoded command data
+   * @return 1: Success, -1: Error
+   */
+  int AnalyzeCmdSetTime(std::vector<uint8_t> decoded_rx);
+
   /**
    * @fn AnalyzeCmdRequestTlm
    * @brief Analyze request telemetry command
    * @param [in] decoded_rx: Decoded command data
    * @return 1: Success, -1: Error
    */
-  int AnalyzeCmd(std::vector<uint8_t> decoded_rx);
-  int AnalyzeCmdSetTime(std::vector<uint8_t> decoded_rx);
   int AnalyzeCmdRequestTlm(std::vector<uint8_t> decoded_rx);
+
   /**
    * @fn AnalyzeTlmId
    * @brief Analyze telemetry ID

--- a/src/component/aocs/sagitta.hpp
+++ b/src/component/aocs/sagitta.hpp
@@ -110,6 +110,7 @@ class Sagitta : public StarSensor, public UartCommunicationWithObc {
   static const uint8_t kTelemIdSolution_ = 0x18;            //!< Solution telemetry ID
   static const uint8_t kTelemIdTemperature_ = 0x1B;         //!< Temperature telemetry ID
   static const uint8_t kActionIdBoot_ = 0x01;               //!< Boot action ID
+  static const uint8_t kActionIdSetTime_ = 0x0E;            //!< Set Time action ID
   static const uint8_t kParamIdMountingQuaternion_ = 0x06;  //!< Mounting quaternion parameter ID
   static const uint8_t kParamRegion_ = 0x01;                //!< Region parameter ID
   static const uint8_t kParamSubscription = 0x12;           //!< Subscription parameter ID
@@ -139,6 +140,8 @@ class Sagitta : public StarSensor, public UartCommunicationWithObc {
    * @param [in] decoded_rx: Decoded command data
    * @return 1: Success, -1: Error
    */
+  int AnalyzeCmd(std::vector<uint8_t> decoded_rx);
+  int AnalyzeCmdSetTime(std::vector<uint8_t> decoded_rx);
   int AnalyzeCmdRequestTlm(std::vector<uint8_t> decoded_rx);
   /**
    * @fn AnalyzeTlmId


### PR DESCRIPTION
## Issue
#9 

## 詳細
SagittaのUnixTime変更コマンドに対応できるようにした

## 検証結果
SILSでUnixTime変更コマンドを送信すると、テレメ上でUnixTimeが変更されていることが確認できた。

今回の変更後も、ほかのコマンド解釈に影響がないことを、Bootコマンド等を打つことで確認した。

## 補足
NA
<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
