### PR TITLE
[HotFix] Fix RW log header to suit with the latest s2e-core version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_policy(SET CMP0048 NEW)
 project(S2E_AOBC
   LANGUAGES CXX
   DESCRIPTION "S2E_AOBC"
-  VERSION 5.0.1
+  VERSION 5.0.2
   )
 
 cmake_minimum_required(VERSION 3.13)

--- a/src/component/aocs/rw0003.cpp
+++ b/src/component/aocs/rw0003.cpp
@@ -42,8 +42,9 @@ std::string Rw0003::GetLogHeader() const {
   std::string str_tmp = "";
 
   str_tmp += WriteScalar("RW0003_angular_velocity", "rad/s");
-  str_tmp += WriteScalar("RW0003_angular_velocity_rpm", "rpm");
+  str_tmp += WriteScalar("RW0003_angular_velocity", "rpm");
   str_tmp += WriteScalar("RW0003_angular_velocity_upper_limit", "rpm");
+  str_tmp += WriteScalar("RW0003_target_angular_acceleration", "rad/s2");
   str_tmp += WriteScalar("RW0003_angular_acceleration", "rad/s^2");
 
   if (is_logged_jitter_) {


### PR DESCRIPTION
## Issue
NA

## 詳細
S2E-COREのRWログが追加されたことに伴う、RW0003ヘッダ情報の修正。

## 検証結果
修正前後でRW0003テレメヘッダ情報が正しくなったことを確認した。

<img width="721" alt="image" src="https://github.com/ut-issl/s2e-aobc/assets/19573779/bb81eefe-112b-447a-9766-cc67a6eff3b3">

## 補足
NA

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
