### PR TITLE
Fault State テレメの追加

### DIFF
--- a/src/component/aocs/rw0003.cpp
+++ b/src/component/aocs/rw0003.cpp
@@ -32,6 +32,7 @@ void Rw0003::MainRoutine(const int time_count) {
     CalcTorque();
     WriteFloatTlm(kReadAddressTemperature_, (float)temperature_degC_);
     WriteFloatTlm(kReadAddressSpeed_, (float)angular_velocity_rad_s_);
+    WriteFloatTlm(kReadAddressFaultState_, (float)fault_state_);
   }
 
   is_command_written_ = false;

--- a/src/component/aocs/rw0003.hpp
+++ b/src/component/aocs/rw0003.hpp
@@ -48,6 +48,7 @@ class Rw0003 : public ReactionWheel, public I2cTargetCommunicationWithObc {
  private:
   bool is_rw_initialized_ = false;  //!< Flag to detect initializing operation
   double temperature_degC_ = 30.0;  //!< RW measured temperature [degC] (dummy data)
+  float fault_state_ = 0.0;         //!< 1.0: wheel is in an fault, 0.0: otherwise
 
   // Communication
   uint16_t crc_;                             //!< Calculated CRC value
@@ -71,6 +72,7 @@ class Rw0003 : public ReactionWheel, public I2cTargetCommunicationWithObc {
   // Register address
   static const uint8_t kReadAddressTemperature_ = 0x03;  //!< Register address of temperature measurement
   static const uint8_t kReadAddressSpeed_ = 0x15;        //!< Register address of rotation speed measurement
+  static const uint8_t kReadAddressFaultState_ = 0x19;   //!< Register address of fault state
   static const uint8_t kReadAddressLimitSpeed1_ = 0x33;  //!< Register address of limit speed 1
   static const uint8_t kReadAddressLimitSpeed2_ = 0x34;  //!< Register address of limit speed 2
 


### PR DESCRIPTION
## Issue
Close #98 

## 詳細
Issue参照

## 検証結果
- SILSでfault stateテレメを取得できていることを確認
- SILSでRWのCRCエラーが出なくなることを確認
<img width="711" alt="スクリーンショット 2024-06-14 9 48 23" src="https://github.com/ut-issl/s2e-aobc/assets/82629762/f8dc80bb-cb08-4379-9aed-95dab83573e2">


## 補足
Fault State テレメは、0 or 1のboolではなく、floatの 0.0 or 1.0 として送られてくる。

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
